### PR TITLE
Fb cpolicy

### DIFF
--- a/includes/util.inc
+++ b/includes/util.inc
@@ -72,11 +72,17 @@ function islandora_utils_ingest_collection($title, $descript, $namespace = 'isla
     if (!empty($cmodels)) {
       $cmodel_xml = '';
       foreach($cmodels as $cm) {
-        $cmodel_xml .= sprintf("<content_model dsid=\"%s\" name=\"%s\" namespace=\"%s\" pid=\"%s\"/>",
-            $cm['dsid'],
-            $cm['name'],
-            $cm['namespace'],
-            $cm['pid']
+        $check = islandora_object_load($cm);
+        $ds = islandora_datastream_load('DC', $check);
+        $xml = simplexml_load_string($ds->content);
+        $dc = $xml->children('dc', TRUE);
+        $dc_title = $dc->title;
+        $dc_pid = $dc->identifier;
+            $cmodel_xml .= sprintf("<content_model dsid=\"%s\" name=\"%s\" namespace=\"%s\" pid=\"%s\"/>",
+            '',
+            $dc_title,
+            $check['namespace'],
+            $dc_pid
             );
       }
     }

--- a/includes/util.inc
+++ b/includes/util.inc
@@ -72,8 +72,8 @@ function islandora_utils_ingest_collection($title, $descript, $pid = 'islandora'
     if (!empty($cmodels)) {
       $cmodel_xml = '';
       foreach($cmodels as $cm) {
-        $check = islandora_object_load($cm);
-        $ds = islandora_datastream_load('DC', $check);
+        $cmodel_obj = islandora_object_load($cm);
+        $ds = islandora_datastream_load('DC', $cmodel_obj);
         $xml = simplexml_load_string($ds->content);
         $dc = $xml->children('dc', TRUE);
         $dc_title = $dc->title;

--- a/includes/util.inc
+++ b/includes/util.inc
@@ -61,7 +61,7 @@ function output_result($pids){
  * @param string $parent
  *   The PID of the parent collection the newly created collection.
  */
-function islandora_utils_ingest_collection($title, $descript, $namespace = 'islandora', $parent = 'islandora:root') {
+function islandora_utils_ingest_collection($title, $descript, $namespace = 'islandora', $parent = 'islandora:root', $cmodels = array()) {
 
   try {
     $tuque = new IslandoraTuque();
@@ -69,9 +69,23 @@ function islandora_utils_ingest_collection($title, $descript, $namespace = 'isla
     $collection_object = $repository->constructObject($namespace);
     $collection_object->label = $title;
 
+    if (!empty($cmodels)) {
+      $cmodel_xml = '';
+      foreach($cmodels as $cm) {
+        $cmodel_xml .= sprintf("<content_model dsid=\"%s\" name=\"%s\" namespace=\"%s\" pid=\"%s\"/>",
+            $cm['dsid'],
+            $cm['name'],
+            $cm['namespace'],
+            $cm['pid']
+            );
+      }
+    }
+    else {
+      $cmodel_xml = '';
+    }
     $collection_policy_xml = <<<EOCP
 <collection_policy xmlns="http://www.islandora.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="$title" xsi:schemaLocation="http://www.islandora.ca http://syn.lib.umanitoba.ca/collection_policy.xsd">
-<content_models/>
+<content_models>$cmodel_xml</content_models>
 <search_terms/>
 <staging_area/>
 <relationship>isMemberOfCollection</relationship>
@@ -142,9 +156,17 @@ EODC;
     $mods_datastream->setContentFromString($mods_xml);
     $collection_object->ingestDatastream($mods_datastream);
 
+    // Borrowed from mjordan remote resource soln. pack.
+    $path_to_mods_to_dc_xsl = file_get_contents(drupal_get_path('module', 'islandora_batch') . '/transforms/mods_to_dc.xsl');
+    $dc_xml = apply_xslt($path_to_mods_to_dc_xsl, $mods_datastream->content);
+    $dc_datastream = $collection_object->constructDatastream('DC', 'M');
+    $dc_datastream->label = 'DC Record';
+    $dc_datastream->mimetype = 'application/xml';
+    $dc_datastream->setContentFromString($dc_xml);
+    $collection_object->ingestDatastream($dc_datastream);
 
     // Handle TN.
-    $path_to_thumbnail = drupal_get_path('module', 'islandora_basic_collection').'/images/folder.png';
+    $path_to_thumbnail = drupal_get_path('module', 'islandora_basic_collection') . '/images/folder.png';
     $tn_datastream = $collection_object->constructDatastream('TN', 'M');
     $tn_mime_detector = new MimeDetect();
     $tn_datastream->mimetype = $tn_mime_detector->getMimetype($path_to_thumbnail);
@@ -160,13 +182,56 @@ EODC;
     $repository->ingestObject($collection_object);
     drupal_set_message(t('Ingested Islandora collection object %t (PID %p).',
       array('%t' => $collection_object->label, '%p' => $collection_object->id)));
-    watchdog('islandora_migrate_cdm_collections', 'Ingested Islandora collection object %t (PID %p).',
+    watchdog('islandora_utils', 'Ingested Islandora collection object %t (PID %p).',
       array('%t' => $collection_object->label, '%p' => $collection_object->id), WATCHDOG_INFO);
   }
   catch (Exception $e) {
     drupal_set_message(t('Error ingesting Islandora collection object %t (PID %p).',
       array('%t' => $collection_object->title, '%p' => $collection_object->id)), 'error');
-    watchdog('islandora_migrate_cdm_collections', 'Error ingesting Islandora collection object %t (PID %p).',
+    watchdog('islandora_utils', 'Error ingesting Islandora collection object %t (PID %p).',
       array('%t' => $title, '%p' => $collection_object->id), WATCHDOG_ERROR);
+  }
+}
+
+/**
+ * Applies an XSLT transform to an XML string.
+ *
+ * @param string $xslt
+ *   An XSLT stylesheet.
+ * @param string $input_xml
+ *   An XML string.
+ * @param array $params
+ *   An associative array of parameters to the stylesheet.
+ *
+ * @return string
+ *   The transformed XML.
+ */
+function apply_xslt($xslt, $input_xml, $params = array()) {
+  try {
+    $xsl_doc = new DOMDocument();
+    $xsl_doc->loadXML($xslt);
+    $xml_doc = new DOMDocument();
+    $xml_doc->loadXML($input_xml);
+    $xslt_proc = new XSLTProcessor();
+    $xslt_proc->importStylesheet($xsl_doc);
+    if (count($params)) {
+      foreach ($params as $param_name => $param_value) {
+        $xslt_proc->setParameter(NULL, $param_name, check_plain($param_value));
+      }
+    }
+    $output_xml = $xslt_proc->transformToXML($xml_doc);
+    return $output_xml;
+  }
+  catch (exception $e) {
+    $success = array(
+      'success' => FALSE,
+      'messages' => array(
+        array(
+          'message' => t('Failed to apply XSL transform.'),
+          'type' => 'watchdog',
+          'severity' => WATCHDOG_ERROR,
+        ),
+      ),
+    );
   }
 }

--- a/includes/util.inc
+++ b/includes/util.inc
@@ -61,14 +61,14 @@ function output_result($pids){
  * @param string $parent
  *   The PID of the parent collection the newly created collection.
  */
-function islandora_utils_ingest_collection($title, $descript, $namespace = 'islandora', $parent = 'islandora:root', $cmodels = array()) {
+function islandora_utils_ingest_collection($title, $descript, $pid = 'islandora', $parent = 'islandora:root', $cmodels = array()) {
 
   try {
     $tuque = new IslandoraTuque();
     $repository = $tuque->repository;
-    $collection_object = $repository->constructObject($namespace);
+    $collection_object = $repository->constructObject($pid);
     $collection_object->label = $title;
-
+    $namespace = array_shift(explode(':',$pid));
     if (!empty($cmodels)) {
       $cmodel_xml = '';
       foreach($cmodels as $cm) {
@@ -81,7 +81,7 @@ function islandora_utils_ingest_collection($title, $descript, $namespace = 'isla
             $cmodel_xml .= sprintf("<content_model dsid=\"%s\" name=\"%s\" namespace=\"%s\" pid=\"%s\"/>",
             '',
             $dc_title,
-            $check['namespace'],
+            $namespace,
             $dc_pid
             );
       }

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -151,7 +151,7 @@ function islandora_utils_drush_command() {
       'islandora_basic_collection',
     ),
     'options' => array(
-      'namespace' => array(
+      'pid' => array(
         'description' => dt('PID to assign to the collection.'),
         'required' => TRUE,
       ),
@@ -376,16 +376,16 @@ function drush_islandora_utils_get_objects_changed_dsid(){
 
 function drush_islandora_utils_create_collection() {
   require_once('includes/util.inc');
-  $namespace = drush_get_option('namespace');
+  $pid = drush_get_option('pid');
   $parent = drush_get_option('parent');
   $title = drush_get_option('title');
   $descript = drush_get_option('description');
-  $cmodels = drush_get_option('cmodels');
+$cmodels = explode(',',drush_get_option('cmodels'));
 
   if (islandora_object_load($namespace)) {
-    drush_log("$namespace has already been ingested.\n", "success");
+    drush_log("$pid has already been ingested.\n", "success");
   }
   else {
-    islandora_utils_ingest_collection($title, $descript, $namespace, $parent, $cmodels);
+    islandora_utils_ingest_collection($title, $descript, $pid, $parent, $cmodels);
   }
 }

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -144,7 +144,7 @@ function islandora_utils_drush_command() {
   );
   $items['islandora-utils-create-collection'] = array(
     'description' => dt('Create a collection container.'),
-    'examples' => array('drush islandora-utils-create-collection --parent=islandora:root --namespace=my:collection'),
+    'examples' => array('drush islandora-utils-create-collection --parent=islandora:root --pid=my:collection'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
     'drupal dependencies' => array(
       'islandora',
@@ -380,9 +380,9 @@ function drush_islandora_utils_create_collection() {
   $parent = drush_get_option('parent');
   $title = drush_get_option('title');
   $descript = drush_get_option('description');
-$cmodels = explode(',',drush_get_option('cmodels'));
+  $cmodels = explode(',',drush_get_option('cmodels'));
 
-  if (islandora_object_load($namespace)) {
+  if (islandora_object_load($pid)) {
     drush_log("$pid has already been ingested.\n", "success");
   }
   else {

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -166,6 +166,10 @@ function islandora_utils_drush_command() {
       'description' => array(
         dt("Description of the collection."),
         'required' => TRUE,
+      ),
+      'cmodels' => array(
+        dt("list of content models to give to the collection. ie islandora:sp_large_image_cmodel,islandora:sp_pdf"),
+        'required' => TRUE,
       )
     ),
   );
@@ -376,11 +380,12 @@ function drush_islandora_utils_create_collection() {
   $parent = drush_get_option('parent');
   $title = drush_get_option('title');
   $descript = drush_get_option('description');
+  $cmodels = drush_get_option('cmodels');
 
   if (islandora_object_load($namespace)) {
     drush_log("$namespace has already been ingested.\n", "success");
   }
   else {
-    islandora_utils_ingest_collection($title, $descript, $namespace, $parent);
+    islandora_utils_ingest_collection($title, $descript, $namespace, $parent, $cmodels);
   }
 }


### PR DESCRIPTION
adds necessary fields to collection policy, bringing them in from the content model object. 

This allows anyone to create a content model, and still use islandora utils to create a collection policy with even a custom content model.

