### PR TITLE
Following datastream version code

### DIFF
--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -364,8 +364,8 @@ function drush_islandora_utils_get_objects_changed_dsid(){
   foreach($pids as $pid) {
     drush_log(sprintf("checking %s for %s", $dsid, $pid), LogLevel::DEBUG);
     $islandora_object = islandora_object_load($pid);
-    $datastream = islandora_datastream_load($dsid, $islandora_object);
-    if (!$islandora_object[$dsid]) {
+    $datastream = $islandora_object[$dsid];
+    if (!$datastream) {
       drush_log("$dsid NOT FOUND for $pid", LogLevel::DEBUG);
       continue;
     }
@@ -373,6 +373,7 @@ function drush_islandora_utils_get_objects_changed_dsid(){
     # But all $datastream values are active versions.  
     # So, we loop over the $datastream items, and pull in 
     # extra information from the matching #audit_values item.
+    # Date of creation is treated as a unique id for matching items.
     $rows = array();
     $audit_values = islandora_get_audit_trail($pid, $dsid);
     foreach ($datastream as $version => $datastream_version) {
@@ -386,11 +387,9 @@ function drush_islandora_utils_get_objects_changed_dsid(){
       }
       $edited_date = $datastream_version->createdDate->format(DATE_RFC850);
       foreach ($rows as &$item) {
-        if ($item['pid'] == ($pid . "." . $dsid)) {
-          if (strval($item['user']) == strval($responsibility)) {
-            array_push($item['time'], $edited_date);
-            continue 2;
-          }
+        if (strval($item['user']) == strval($responsibility)) {
+          array_push($item['time'], $edited_date);
+          continue 2;
         }
       }
       $row = array(
@@ -399,7 +398,7 @@ function drush_islandora_utils_get_objects_changed_dsid(){
         'time' => array($edited_date),
         );
       $rows[] = $row;
-      }
+    }
     $pid_histories[] = $rows;
   }
   $toFile = json_encode($pid_histories);

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -352,22 +352,14 @@ function drush_islandora_utils_get_objects_missing_dsid() {
   }
 }
 
-function drush_islandora_utils_get_objects_changed_dsid(){
-  require_once('includes/util.inc');
-  module_load_include('inc', 'islandora', 'includes/datastream.version');
-  $coll = drush_get_option('collection');
-  $dsid = drush_get_option('dsid');
-  $outfile = drush_get_option('outfile');
-  $pids = get_collection_members($coll);
-  drush_log(sprintf("found %s pids", count($pids)), LogLevel::DEBUG);
-  $pid_histories = array();
-  foreach($pids as $pid) {
+
+function get_history_of_pid($pid, $dsid){
     drush_log(sprintf("checking %s for %s", $dsid, $pid), LogLevel::DEBUG);
     $islandora_object = islandora_object_load($pid);
     $datastream = $islandora_object[$dsid];
     if (!$datastream) {
       drush_log("$dsid NOT FOUND for $pid", LogLevel::DEBUG);
-      continue;
+      return False;
     }
     # $audit_values include item versions that were deleted, etc.
     # But all $datastream values are active versions.  
@@ -399,11 +391,30 @@ function drush_islandora_utils_get_objects_changed_dsid(){
         );
       $rows[] = $row;
     }
-    $pid_histories[] = $rows;
+    return $rows;
+}
+
+
+function filter_unchanged_from_pid_history($pids_histories){
+  $retained_history = array();
+  foreach ($pids_histories as $pid_history){
+    if (count($pid_history) > 1) {
+      $retained_history[] = $pid_history;
+      continue;
+    }
+    foreach ($pid_history as $event){
+      if (count($event['time']) > 1) {
+        $retained_history[] = $pid_history;
+        continue 2;
+      }
+    }
   }
-  $toFile = json_encode($pid_histories);
-  file_put_contents($outfile, $toFile.PHP_EOL , FILE_APPEND );
-  foreach ($pid_histories as $counter=>$per_pid) {
+  return $retained_history;
+}
+
+
+function console_print_results($pids_histories, $dsid){
+    foreach ($pids_histories as $counter=>$per_pid) {
     $notify = false;
     $editors_count = count($per_pid);
     if ($editors_count > 1) {
@@ -427,6 +438,28 @@ function drush_islandora_utils_get_objects_changed_dsid(){
     }
   }
 }
+
+function drush_islandora_utils_get_objects_changed_dsid(){
+  require_once('includes/util.inc');
+  module_load_include('inc', 'islandora', 'includes/datastream.version');
+  $coll = drush_get_option('collection');
+  $dsid = drush_get_option('dsid');
+  $outfile = drush_get_option('outfile');
+  $pids = get_collection_members($coll);
+  drush_log(sprintf("found %s pids", count($pids)), LogLevel::DEBUG);
+  $pids_histories = array();
+  foreach($pids as $pid) {
+    $pid_history = get_history_of_pid($pid, $dsid);
+    if ($pid_history) {
+      $pids_histories[] = $pid_history;
+    }
+  }
+  $filtered_histories = filter_unchanged_from_pid_history($pids_histories);
+  $toFile = json_encode($filtered_histories);
+  file_put_contents($outfile, $toFile.PHP_EOL , FILE_APPEND );
+  console_print_results($pids_histories, $dsid);
+}
+
 
 function drush_islandora_utils_create_collection() {
   require_once('includes/util.inc');

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -354,55 +354,55 @@ function drush_islandora_utils_get_objects_missing_dsid() {
 
 
 function get_history_of_pid($pid, $dsid){
-    drush_log(sprintf("checking %s for %s", $dsid, $pid), LogLevel::DEBUG);
-    $islandora_object = islandora_object_load($pid);
-    $datastream = $islandora_object[$dsid];
-    if (!$datastream) {
-      drush_log("$dsid NOT FOUND for $pid", LogLevel::DEBUG);
-      return False;
-    }
-    # $audit_values include item versions that were deleted, etc.
-    # But all $datastream values are active versions.  
-    # So, we loop over the $datastream items, and pull in 
-    # extra information from the matching #audit_values item.
-    # Date of creation is treated as a unique id for matching items.
-    $rows = array();
-    $audit_values = islandora_get_audit_trail($pid, $dsid);
-    foreach ($datastream as $version => $datastream_version) {
-      $responsibility = $islandora_object->owner;    
-      # finds a better author name from audit_value, if possible.
-      foreach ($audit_values as $audit_value) {
-        if ($audit_value['date'] == $datastream_version->createdDate) {
-          $responsibility = strval($audit_value['responsibility']);
-          break;
-        }
+  drush_log(sprintf("checking %s for %s", $dsid, $pid), LogLevel::DEBUG);
+  $islandora_object = islandora_object_load($pid);
+  $datastream = $islandora_object[$dsid];
+  if (!$datastream) {
+    drush_log("$dsid NOT FOUND for $pid", LogLevel::DEBUG);
+    return False;
+  }
+  # $audit_values include item versions that were deleted, etc.
+  # But all $datastream values are active versions.  
+  # So, we loop over the $datastream items, and pull in 
+  # extra information from the matching #audit_values item.
+  # Date of creation is treated as a unique id for matching items.
+  $rows = array();
+  $audit_values = islandora_get_audit_trail($pid, $dsid);
+  foreach ($datastream as $version => $datastream_version) {
+    $responsibility = $islandora_object->owner;
+    // finds a better author name from audit_value, if possible.
+    foreach ($audit_values as $audit_value) {
+      if ($audit_value['date'] == $datastream_version->createdDate) {
+        $responsibility = strval($audit_value['responsibility']);
+        break;
       }
-      $edited_date = $datastream_version->createdDate->format(DATE_RFC850);
-      foreach ($rows as &$item) {
-        if (strval($item['user']) == strval($responsibility)) {
-          array_push($item['time'], $edited_date);
-          continue 2;
-        }
-      }
-      $row = array(
-        'pid' => $pid . "." . $dsid, 
-        'user' => $responsibility,
-        'time' => array($edited_date),
-        );
-      $rows[] = $row;
     }
-    return $rows;
+    $edited_date = $datastream_version->createdDate->format(DATE_RFC850);
+    foreach ($rows as &$item) {
+      if (strval($item['user']) == strval($responsibility)) {
+        array_push($item['time'], $edited_date);
+        continue 2;
+      }
+    }
+    $row = array(
+      'pid' => $pid . "." . $dsid, 
+      'user' => $responsibility,
+      'time' => array($edited_date),
+      );
+    $rows[] = $row;
+  }
+  return $rows;
 }
 
 
 function filter_unchanged_from_pid_history($pids_histories){
   $retained_history = array();
-  foreach ($pids_histories as $pid_history){
+  foreach ($pids_histories as $pid_history) {
     if (count($pid_history) > 1) {
       $retained_history[] = $pid_history;
       continue;
     }
-    foreach ($pid_history as $event){
+    foreach ($pid_history as $event) {
       if (count($event['time']) > 1) {
         $retained_history[] = $pid_history;
         continue 2;
@@ -412,9 +412,8 @@ function filter_unchanged_from_pid_history($pids_histories){
   return $retained_history;
 }
 
-
 function console_print_results($pids_histories, $dsid){
-    foreach ($pids_histories as $counter=>$per_pid) {
+  foreach ($pids_histories as $counter=>$per_pid) {
     $notify = false;
     $editors_count = count($per_pid);
     if ($editors_count > 1) {

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -362,44 +362,93 @@ function drush_islandora_utils_get_objects_changed_dsid(){
   $tuque = islandora_get_tuque_connection();
   $repo = $tuque->repository;
   drush_log(sprintf("found %s pids", count($pids)), LogLevel::DEBUG);
-  foreach($pids as $pid){
+  $pid_histories = array();
+  foreach($pids as $pid) {
     drush_log(sprintf("checking %s for %s", $dsid, $pid), LogLevel::DEBUG);
     $audit_values = islandora_get_audit_trail($pid, $dsid);
     $islandora_object = islandora_object_load($pid);
     $datastream = islandora_datastream_load($dsid, $islandora_object);
+    if (!$islandora_object[$dsid]) {
+      drush_log("$dsid NOT FOUND for $pid", LogLevel::DEBUG);
+      continue;
+    }
     $rows = array();
+    # all $datastream items are valid, but not all $audit_values are.
     foreach ($datastream as $version => $datastream_version) {
-      $row = array();
-//      if (!$audit_values) {
-       $responsibility = $islandora_object->owner;       
-//      }
-//      else {
+      $responsibility = $islandora_object->owner;    
+      # finds a better author name from audit_value, if possible.
       foreach ($audit_values as $audit_value) {
         if ($audit_value['date'] == $datastream_version->createdDate) {
-          $responsibility = $audit_value['responsibility'];
-//        }
+          $responsibility = strval($audit_value['responsibility']);
+        }
       }
+      $edited_date = $datastream_version->createdDate->format(DATE_RFC850);
+      foreach ($rows as &$item) {
+        echo ($item['pid'] . " versus " . ($pid . "." . $dsid) . "\n");
+        if ($item['pid'] == ($pid . "." . $dsid)) {
+//          echo "equals?\n";
+//          echo strval($item['user']) . "\n";
+//          echo strval($responsibility). "\n";
+//          echo strval($item['user']) == strval($responsibility);
+//          echo "\n";
+          if (strval($item['user']) == strval($responsibility)) {
+            array_push($item['time'], $edited_date);
+            continue 2;
+          }
+        }
       }
-      $row[] = array('user' => $responsibility,
-        'time' => $datastream_version->createdDate->format(DATE_RFC850));
+      $row = array(
+        'pid' => $pid . "." . $dsid, 
+        'user' => $responsibility,
+        'time' => array($edited_date),
+        );
+//      echo "row\n";
+//      var_dump($row);
       $rows[] = $row;
-    }
-  }
-    $count = count($rows);
-    if($count > 1){
-      if($outfile){
-        $toFile = 'PID: '.$pid.' , '.'number of versions: '.$count.' at time: '.$when.' by: '.$whom;
-        file_put_contents($outfile, $toFile.PHP_EOL , FILE_APPEND );
       }
-      drush_log("changed $dsid and number of versions for $pid = $count, last changed @ $when , by $whom", LogLevel::WARNING);
+    echo "rows\n";
+    var_dump($rows);
+    $pid_histories[] = $rows;
+  }
+  echo "pid histories\n";
+  var_dump($pid_histories);
+  $toFile = json_encode($pid_histories);
+  file_put_contents($outfile, $toFile.PHP_EOL , FILE_APPEND );
+
+
+
+  foreach ($pid_histories as $counter=>$per_pid) {
+//    echo "per pid\n";
+//    echo $per_pid;
+//    echo "\n";
+//    var_dump($per_pid);
+    $notify = false;
+    $editors_count = count($per_pid);
+    if ($editors_count > 1) {
+      $notify = true;
     }
-    elseif($count == 1) {
-      drush_log("Only one version found for $dsid in $pid", LogLevel::DEBUG);
-    }
-    else {
-      drush_log("$dsid NOT FOUND in $pid", LogLevel::ERROR);
+    foreach ($per_pid as $per_editor) {
+//      echo "per_editor\n";
+//      var_dump($per_editor);
+      $editor = $per_editor['user'];
+      $pid = $per_editor['pid'];
+      $times_array = $per_editor['time'];
+//      echo "per editor info\n";
+//      echo $editor . ", " . $pid . ", " . $times_array . "\n";
+      $times_count = count($times_array);
+      $times_string = implode('; ', $times_array);
+      if ($times_count > 1) {
+        $notify = true;
+      }
+      if ($notify) {
+        drush_log("$dsid for $pid has $times_count changes by $editor on $times_string", LogLevel::WARNING);
+      }
+    } 
+    if ($notify) {
+      drush_log("$dsid for $pid has $editors_count editors", LogLevel::WARNING);
     }
   }
+}
 
 function drush_islandora_utils_create_collection() {
   require_once('includes/util.inc');

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -359,38 +359,34 @@ function drush_islandora_utils_get_objects_changed_dsid(){
   $dsid = drush_get_option('dsid');
   $outfile = drush_get_option('outfile');
   $pids = get_collection_members($coll);
-  $tuque = islandora_get_tuque_connection();
-  $repo = $tuque->repository;
   drush_log(sprintf("found %s pids", count($pids)), LogLevel::DEBUG);
   $pid_histories = array();
   foreach($pids as $pid) {
     drush_log(sprintf("checking %s for %s", $dsid, $pid), LogLevel::DEBUG);
-    $audit_values = islandora_get_audit_trail($pid, $dsid);
     $islandora_object = islandora_object_load($pid);
     $datastream = islandora_datastream_load($dsid, $islandora_object);
     if (!$islandora_object[$dsid]) {
       drush_log("$dsid NOT FOUND for $pid", LogLevel::DEBUG);
       continue;
     }
+    # $audit_values include item versions that were deleted, etc.
+    # But all $datastream values are active versions.  
+    # So, we loop over the $datastream items, and pull in 
+    # extra information from the matching #audit_values item.
     $rows = array();
-    # all $datastream items are valid, but not all $audit_values are.
+    $audit_values = islandora_get_audit_trail($pid, $dsid);
     foreach ($datastream as $version => $datastream_version) {
       $responsibility = $islandora_object->owner;    
       # finds a better author name from audit_value, if possible.
       foreach ($audit_values as $audit_value) {
         if ($audit_value['date'] == $datastream_version->createdDate) {
           $responsibility = strval($audit_value['responsibility']);
+          break;
         }
       }
       $edited_date = $datastream_version->createdDate->format(DATE_RFC850);
       foreach ($rows as &$item) {
-        echo ($item['pid'] . " versus " . ($pid . "." . $dsid) . "\n");
         if ($item['pid'] == ($pid . "." . $dsid)) {
-//          echo "equals?\n";
-//          echo strval($item['user']) . "\n";
-//          echo strval($responsibility). "\n";
-//          echo strval($item['user']) == strval($responsibility);
-//          echo "\n";
           if (strval($item['user']) == strval($responsibility)) {
             array_push($item['time'], $edited_date);
             continue 2;
@@ -402,39 +398,22 @@ function drush_islandora_utils_get_objects_changed_dsid(){
         'user' => $responsibility,
         'time' => array($edited_date),
         );
-//      echo "row\n";
-//      var_dump($row);
       $rows[] = $row;
       }
-    echo "rows\n";
-    var_dump($rows);
     $pid_histories[] = $rows;
   }
-  echo "pid histories\n";
-  var_dump($pid_histories);
   $toFile = json_encode($pid_histories);
   file_put_contents($outfile, $toFile.PHP_EOL , FILE_APPEND );
-
-
-
   foreach ($pid_histories as $counter=>$per_pid) {
-//    echo "per pid\n";
-//    echo $per_pid;
-//    echo "\n";
-//    var_dump($per_pid);
     $notify = false;
     $editors_count = count($per_pid);
     if ($editors_count > 1) {
       $notify = true;
     }
     foreach ($per_pid as $per_editor) {
-//      echo "per_editor\n";
-//      var_dump($per_editor);
       $editor = $per_editor['user'];
       $pid = $per_editor['pid'];
       $times_array = $per_editor['time'];
-//      echo "per editor info\n";
-//      echo $editor . ", " . $pid . ", " . $times_array . "\n";
       $times_count = count($times_array);
       $times_string = implode('; ', $times_array);
       if ($times_count > 1) {

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -357,27 +357,35 @@ function drush_islandora_utils_get_objects_changed_dsid(){
   module_load_include('inc', 'islandora', 'includes/datastream.version');
   $coll = drush_get_option('collection');
   $dsid = drush_get_option('dsid');
-  $pids = get_collection_members($coll);
   $outfile = drush_get_option('outfile');
+  $pids = get_collection_members($coll);
+  $tuque = islandora_get_tuque_connection();
+  $repo = $tuque->repository;
   drush_log(sprintf("found %s pids", count($pids)), LogLevel::DEBUG);
   foreach($pids as $pid){
     drush_log(sprintf("checking %s for %s", $dsid, $pid), LogLevel::DEBUG);
-    $object = islandora_object_load($pid);
-    $repo = $object->repository;
-    $api_m = $repo->api->m;
-    $data = islandora_get_audit_trail($pid,$dsid);
-
-    if(!empty($data) && array_key_exists(0, $data) && array_key_exists('responsibility', $data[0])){
-      $whom = $data[0]['responsibility'];
+    $audit_values = islandora_get_audit_trail($pid, $dsid);
+    $islandora_object = islandora_object_load($pid);
+    $datastream = islandora_datastream_load($dsid, $islandora_object);
+    $rows = array();
+    foreach ($datastream as $version => $datastream_version) {
+      $row = array();
+//      if (!$audit_values) {
+       $responsibility = $islandora_object->owner;       
+//      }
+//      else {
+      foreach ($audit_values as $audit_value) {
+        if ($audit_value['date'] == $datastream_version->createdDate) {
+          $responsibility = $audit_value['responsibility'];
+//        }
+      }
+      }
+      $row[] = array('user' => $responsibility,
+        'time' => $datastream_version->createdDate->format(DATE_RFC850));
+      $rows[] = $row;
     }
-    if(isset($object[$dsid])){
-      $hist = $api_m->getDatastreamHistory($pid, $dsid);
-      $when = $hist[0]['dsCreateDate'];
-    }
-    else {
-      drush_log('datastream non-existant', LogLevel::WARNING);
-    }
-    $count = count($hist);
+  }
+    $count = count($rows);
     if($count > 1){
       if($outfile){
         $toFile = 'PID: '.$pid.' , '.'number of versions: '.$count.' at time: '.$when.' by: '.$whom;
@@ -392,7 +400,6 @@ function drush_islandora_utils_get_objects_changed_dsid(){
       drush_log("$dsid NOT FOUND in $pid", LogLevel::ERROR);
     }
   }
-}
 
 function drush_islandora_utils_create_collection() {
   require_once('includes/util.inc');


### PR DESCRIPTION
The bug where deleted datastream versions would count as versions -- squashed.

Doing so required excising the console print statements, so these were reimplemented as a separate function. The outfile logs only items with multiple authors or versions, as before.  it is formatted as json though now (maybe it helps when piping the output of this function to another script).  