### PR TITLE
Expand book pid pointers

### DIFF
--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -256,28 +256,28 @@ function drush_islandora_utils_get_pids_for_collection() {
   output_result($pids);
 }
 
-/**
- *
- */
 function drush_islandora_utils_get_cdm_pointers_for_collection() {
   require_once 'includes/util.inc';
-  $pid  = drush_get_option('collection');
+  $coll = drush_get_option('collection');
   $ptrs = drush_get_option('infile', FALSE) ? explode(',', file_get_contents(drush_get_option('infile'))) : FALSE;
   $ptrs = $ptrs ? array_map('trim', $ptrs) : $ptrs;
-  $pids = get_collection_members($pid);
+  $pids = get_collection_members($coll);
   $map  = array();
   $hits = array();
 
   foreach ($pids as $pid) {
-    $obj   = islandora_object_load($pid);
-    $mods  = $obj->getDatastream('MODS')->content;
-    $xml   = simplexml_load_string($mods);
-    $ptr   = $xml->extension->CONTENTdmData->pointer;
-    if ($ptrs) {
-      if (in_array($ptr, $ptrs)) {
-        $map[]  = $pid;
-        $hits[] = $ptr;
-      }
+    $obj = islandora_object_load($pid);
+    $cmodel = $obj->models[0];
+    if ($cmodel == "islandora:pageCModel") {
+      $ptr = find_pointer_for_page($obj);
+    } else {
+      $mods = $obj->getDatastream('MODS')->content;
+      $xml = simplexml_load_string($mods);
+      $ptr = $xml->extension->CONTENTdmData->pointer;
+    }
+    if ($ptrs && in_array($ptr, $ptrs)) {
+      $map[] = $pid;
+      $hits[] = $ptr;
     }
     else {
       $map[] = sprintf("%s => %s", $ptr, $pid);
@@ -290,6 +290,14 @@ function drush_islandora_utils_get_cdm_pointers_for_collection() {
   else {
     output_result($map);
   }
+}
+
+function find_pointer_for_page($obj) {
+  $seq_array = $obj->relationships->get("http://islandora.ca/ontology/relsext#", "isSequenceNumber");
+  $seq_num = $seq_array[0]['object']['value'];
+  $book_array = $obj->relationships->get("http://islandora.ca/ontology/relsext#", "isPageOf");
+  $book_pid = $book_array[0]['object']['value'];
+  return "$book_pid PAGE $seq_num";
 }
 
 /**

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -271,9 +271,7 @@ function drush_islandora_utils_get_cdm_pointers_for_collection() {
     if ($cmodel == "islandora:pageCModel") {
       $ptr = find_pointer_for_page($obj);
     } else {
-      $mods = $obj->getDatastream('MODS')->content;
-      $xml = simplexml_load_string($mods);
-      $ptr = $xml->extension->CONTENTdmData->pointer;
+      $ptr = find_pointer_for_normal_obj($obj);
     }
     if ($ptrs && in_array($ptr, $ptrs)) {
       $map[] = $pid;
@@ -297,7 +295,17 @@ function find_pointer_for_page($obj) {
   $seq_num = $seq_array[0]['object']['value'];
   $book_array = $obj->relationships->get("http://islandora.ca/ontology/relsext#", "isPageOf");
   $book_pid = $book_array[0]['object']['value'];
-  return "$book_pid PAGE $seq_num";
+  $book_obj = islandora_object_load($book_pid);
+  $book_pointer = find_pointer_for_normal_obj($book_obj);
+  $ptr = "$book_pointer PAGE $seq_num";
+  return $ptr;
+}
+
+function find_pointer_for_normal_obj($obj) {
+  $mods = $obj->getDatastream('MODS')->content;
+  $xml = simplexml_load_string($mods);
+  $ptr = $xml->extension->CONTENTdmData->pointer;
+  return $ptr;
 }
 
 /**


### PR DESCRIPTION
Page objects can be psuedo-objects.  Those made from split pdfs have no mods per page, nor do they have a matching cDM pointer.  

However, it is sometimes necessary to map a Page pseudo-object to the source item in the zip file.  Previously, there was no automated method.  This pull request creates one.

The output of a normal islandora object (including Book level object, compound parent, compound child, simple object): 
1949 => lsu-testcollection:2, 142 => lsu-testcollection:4, ....etc

The output of a Page object:
1949 PAGE 8 => lsu-testcollection:19,1949 PAGE 6 => lsu-testcollection:17, ....etc

Collections with normal object + Page objects will generate output with both types of output co-mingled.


No fix for newspaper levels, as that will be it's own private Idaho.