### PR TITLE
Consolidate ocr

### DIFF
--- a/includes/util.inc
+++ b/includes/util.inc
@@ -36,7 +36,7 @@ function csv_format_pid_list($pids){
 }
 
 /**
- * 
+ *
  * @param array $pids
  */
 function output_result($pids){
@@ -287,4 +287,14 @@ function islandora_utils_get_mods($params) {
 </mods>
 EODC;
   return $mods_xml;
+}
+
+function childpages($parentpid){
+$tuque = islandora_get_tuque_connection();
+$query = <<<EOQ
+SELECT ?page
+FROM <#ri>
+WHERE {?page <http://islandora.ca/ontology/relsext#isPageOf> <info:fedora/$parentpid>}
+EOQ;
+$childpages =  $tuque->repository->ri->sparqlQuery($query, 'unlimited');
 }

--- a/includes/util.inc
+++ b/includes/util.inc
@@ -288,13 +288,3 @@ function islandora_utils_get_mods($params) {
 EODC;
   return $mods_xml;
 }
-
-function childpages($parentpid){
-$tuque = islandora_get_tuque_connection();
-$query = <<<EOQ
-SELECT ?page
-FROM <#ri>
-WHERE {?page <http://islandora.ca/ontology/relsext#isPageOf> <info:fedora/$parentpid>}
-EOQ;
-$childpages =  $tuque->repository->ri->sparqlQuery($query, 'unlimited');
-}

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -265,12 +265,11 @@ function drush_islandora_utils_ocr_consolidate() {
     foreach ($pages_ocr as $key => $string) {
       $big_string .= $string;
     }
-    $datastream = $parent_obj->constructDatastream('OCR');
+    $datastream =isset($parent_obj['OCR']) ? $parent_obj['OCR'] : $parent_obj->constructDatastream('OCR');
     $datastream->label = 'Consolidated OCR';
     $datastream->mimeType = 'text/plain';
     $datastream->setContentFromString($big_string);
-    drush_print_r($datastream);
-    //$parent_obj->ingestDatastream($datastream);
+    $parent_obj->ingestDatastream($datastream);
   // }
 }
 

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -224,18 +224,18 @@ function islandora_utils_drush_command() {
   $items['islandora-utils-ocr-consolidate'] = array(
     'description' => dt('Consolidate multiple ocr files, for newspapers or books.'),
     'examples' => array('drush islandora-utils-ocr-consolidate -u 1 --pid'),
-    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
     'drupal dependencies' => array(
       'islandora',
       'islandora_paged_content',
     ),
     'options' => array(
       'pid' => array(
-        'description' => dt('single pid.'),
-        'required' => TRUE,
+        'description' => dt('single pid of parent with pages.'),
+        'required' => FALSE,
       ),
-      'parentcoll' => array(
-        'description' => dt('single pid of parent.'),
+      'pidlist' => array(
+        'description' => dt('csv list of pids that contain pages (a series of newspaper issues etc).'),
         'required' => FALSE,
       ),
     ),
@@ -244,33 +244,55 @@ function islandora_utils_drush_command() {
 }
 
 function drush_islandora_utils_ocr_consolidate() {
+  $pid = drush_get_option('pid',FALSE);
+  $pidlist =drush_get_option('pidlist',FALSE);
 
+  if ($pid && $pidlist) {
+    throw new Exception("'pid' and 'pidlist' are mutually exclusive options.");
+  }
+  elseif (!$pid && !$pidlist) {
+    throw new Exception('One of the options [pid,pidlist] is required.');
+  }
+  elseif (!$pid) {
+    $pidlist = trim(file_get_contents($pidlist));
+    $pids = explode(',', $pidlist);
+  }
+  if(isset($pids)){
+    foreach($pids as $singlepid) {
+      drush_print_r($singlepid);
+      consolidate_ocr($singlepid);
+    }
+  }
+  else{
+    $pid = drush_get_option('pid', FALSE);
+    drush_print_r($pid);
+    consolidate_ocr($pid);
+  }
+}
+
+function consolidate_ocr($pid) {
   module_load_include('inc','islandora_utils','includes/util');
   module_load_include('inc','islandora_paged_content', 'includes/utilities');
-  $pid = drush_get_option('pid', FALSE);
   $pages_ocr = array();
-  // foreach($pidlist as $pid) {
-
-    $path = "tmp/$pid" ;
-    $parent_obj = islandora_object_load($pid);
-    $pages = islandora_paged_content_get_pages_ri($parent_obj);
-    foreach($pages as $page) {
-      $page_pid = $page['pid'];
-      $page_obj = islandora_object_load($page_pid);
-      if(isset($page_obj['OCR'])) {
-        $pages_ocr[] = $page_obj['OCR']->content;
-      }
+  $path = "tmp/$pid" ;
+  $parent_obj = islandora_object_load($pid);
+  $pages = islandora_paged_content_get_pages_ri($parent_obj);
+  foreach($pages as $page) {
+    $page_pid = $page['pid'];
+    $page_obj = islandora_object_load($page_pid);
+    if(isset($page_obj['OCR'])) {
+      $pages_ocr[] = $page_obj['OCR']->content;
     }
-    $big_string = '';
-    foreach ($pages_ocr as $key => $string) {
-      $big_string .= $string;
-    }
-    $datastream =isset($parent_obj['OCR']) ? $parent_obj['OCR'] : $parent_obj->constructDatastream('OCR');
-    $datastream->label = 'Consolidated OCR';
-    $datastream->mimeType = 'text/plain';
-    $datastream->setContentFromString($big_string);
-    $parent_obj->ingestDatastream($datastream);
-  // }
+  }
+  $big_string = '';
+  foreach ($pages_ocr as $key => $string) {
+    $big_string .= $string;
+  }
+  $datastream =isset($parent_obj['OCR']) ? $parent_obj['OCR'] : $parent_obj->constructDatastream('OCR');
+  $datastream->label = 'Consolidated OCR';
+  $datastream->mimeType = 'text/plain';
+  $datastream->setContentFromString($big_string);
+  $parent_obj->ingestDatastream($datastream);
 }
 
 function drush_islandora_utils_ingest_item() {

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -230,10 +230,6 @@ function islandora_utils_drush_command() {
       'islandora_paged_content',
     ),
     'options' => array(
-      'path' => array(
-        'description' => dt('path for files'),
-        'required' => TRUE,
-      ),
       'pid' => array(
         'description' => dt('single pid.'),
         'required' => TRUE,
@@ -252,28 +248,29 @@ function drush_islandora_utils_ocr_consolidate() {
   module_load_include('inc','islandora_utils','includes/util');
   module_load_include('inc','islandora_paged_content', 'includes/utilities');
   $pid = drush_get_option('pid', FALSE);
-  $path = drush_get_option('path', FALSE);
   $pages_ocr = array();
   // foreach($pidlist as $pid) {
 
-    $path = "$path/$pid" ;
-    $pages = childpages($pid);
+    $path = "tmp/$pid" ;
+    $parent_obj = islandora_object_load($pid);
+    $pages = islandora_paged_content_get_pages_ri($parent_obj);
     foreach($pages as $page) {
-      $page_obj = islandora_object_load($page['value']);
-      $dsid = 'OCR';
-      if(isset($page_obj[$dsid])) {
-        $pages_ocr[$page['value']] = $page_obj[$dsid];
+      $page_pid = $page['pid'];
+      $page_obj = islandora_object_load($page_pid);
+      if(isset($page_obj['OCR'])) {
+        $pages_ocr[] = $page_obj['OCR']->content;
       }
-
     }
-    $appended = islandora_paged_content_ocr_append($path, $pages_ocr);
-
-    $issue = islandora_object_load($pid);
-    $datastream = $issue->constructDatastream($dsid);
+    $big_string = '';
+    foreach ($pages_ocr as $key => $string) {
+      $big_string .= $string;
+    }
+    $datastream = $parent_obj->constructDatastream('OCR');
     $datastream->label = 'Consolidated OCR';
     $datastream->mimeType = 'text/plain';
-    $datastream->setContentFromFile($path);
-    //$issue->ingestDatastream($appended);
+    $datastream->setContentFromString($big_string);
+    drush_print_r($datastream);
+    //$parent_obj->ingestDatastream($datastream);
   // }
 }
 

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -261,7 +261,7 @@ function drush_islandora_utils_ocr_consolidate() {
   }
   if(isset($pids)){
     foreach($pids as $singlepid) {
-      drush_print($singlepid);
+      drush_log($singlepid . ' now has a consolidated ocr datastream' , success);
       consolidate_ocr($singlepid);
     }
   }

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -221,7 +221,52 @@ function islandora_utils_drush_command() {
         ],
       ],
   );
+  $items['islandora-utils-ocr-consolidate'] = array(
+    'description' => dt('Consolidate multiple ocr files, for newspapers or books.'),
+    'examples' => array('drush islandora-utils-ocr-consolidate -u 1 --pid'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'drupal dependencies' => array(
+      'islandora',
+      'islandora_paged_content',
+    ),
+    'options' => array(
+      'path' => array(
+        'description' => dt('path for files'),
+        'required' => TRUE,
+      ),
+      'pidfile' => array(
+        'description' => dt('list of \n separated pids.'),
+        'required' => TRUE,
+      ),
+    ),
+  );
   return $items;
+}
+
+function drush_islandora_utils_ocr_consolidate() {
+
+  module_load_include('inc','includes/util');
+  module_load_include('inc','islandoar_paged_content', 'includes/utilities');
+  $pidlist = drush_get_option('pidfile', FALSE);
+  $pages_ocr = array();
+  foreach($pidlist as $pid) {
+    $path = "/tmp/$pid".'ocr' ;
+    $pages = childpages($pid);
+    foreach($pages as $page) {
+      $page_obj = islandora_object_load($page['value']);
+      $dsid = 'OCR';
+      if(isset($page_obj[$dsid])) {
+        $pages_ocr[$page['value']] = $page_obj[$dsid];
+      }
+    }
+    islandora_paged_content_ocr_append($path, $pages_ocr );
+    $issue = islandora_object_load($pid);
+    $datastream = $issue->constructDatastream($dsid);
+    $datastream->label = 'Consolidated OCR';
+    $datastream->mimeType = 'text/plain';
+    $datastream->setContentFromFile($path);
+    $issue->ingestDatastream($datastream);
+  }
 }
 
 function drush_islandora_utils_ingest_item() {
@@ -441,8 +486,8 @@ function get_history_of_pid($pid, $dsid){
     return False;
   }
   # $audit_values include item versions that were deleted, etc.
-  # But all $datastream values are active versions.  
-  # So, we loop over the $datastream items, and pull in 
+  # But all $datastream values are active versions.
+  # So, we loop over the $datastream items, and pull in
   # extra information from the matching #audit_values item.
   # Date of creation is treated as a unique id for matching items.
   $rows = array();
@@ -464,7 +509,7 @@ function get_history_of_pid($pid, $dsid){
       }
     }
     $row = array(
-      'pid' => $pid . "." . $dsid, 
+      'pid' => $pid . "." . $dsid,
       'user' => $responsibility,
       'time' => array($edited_date),
       );

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -234,9 +234,13 @@ function islandora_utils_drush_command() {
         'description' => dt('path for files'),
         'required' => TRUE,
       ),
-      'pidfile' => array(
-        'description' => dt('list of \n separated pids.'),
+      'pid' => array(
+        'description' => dt('single pid.'),
         'required' => TRUE,
+      ),
+      'parentcoll' => array(
+        'description' => dt('single pid of parent.'),
+        'required' => FALSE,
       ),
     ),
   );
@@ -245,12 +249,14 @@ function islandora_utils_drush_command() {
 
 function drush_islandora_utils_ocr_consolidate() {
 
-  module_load_include('inc','includes/util');
-  module_load_include('inc','islandoar_paged_content', 'includes/utilities');
-  $pidlist = drush_get_option('pidfile', FALSE);
+  module_load_include('inc','islandora_utils','includes/util');
+  module_load_include('inc','islandora_paged_content', 'includes/utilities');
+  $pid = drush_get_option('pid', FALSE);
+  $path = drush_get_option('path', FALSE);
   $pages_ocr = array();
-  foreach($pidlist as $pid) {
-    $path = "/tmp/$pid".'ocr' ;
+  // foreach($pidlist as $pid) {
+
+    $path = "$path/$pid" ;
     $pages = childpages($pid);
     foreach($pages as $page) {
       $page_obj = islandora_object_load($page['value']);
@@ -258,15 +264,17 @@ function drush_islandora_utils_ocr_consolidate() {
       if(isset($page_obj[$dsid])) {
         $pages_ocr[$page['value']] = $page_obj[$dsid];
       }
+
     }
-    islandora_paged_content_ocr_append($path, $pages_ocr );
+    $appended = islandora_paged_content_ocr_append($path, $pages_ocr);
+
     $issue = islandora_object_load($pid);
     $datastream = $issue->constructDatastream($dsid);
     $datastream->label = 'Consolidated OCR';
     $datastream->mimeType = 'text/plain';
     $datastream->setContentFromFile($path);
-    $issue->ingestDatastream($datastream);
-  }
+    //$issue->ingestDatastream($appended);
+  // }
 }
 
 function drush_islandora_utils_ingest_item() {

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -259,13 +259,13 @@ function drush_islandora_utils_ocr_consolidate() {
   }
   if(isset($pids)){
     foreach($pids as $singlepid) {
-      drush_print_r($singlepid);
+      drush_print($singlepid);
       consolidate_ocr($singlepid);
     }
   }
   else{
     $pid = drush_get_option('pid', FALSE);
-    drush_print_r($pid);
+    drush_print($pid);
     consolidate_ocr($pid);
   }
 }

--- a/islandora_utils.drush.inc
+++ b/islandora_utils.drush.inc
@@ -244,9 +244,8 @@ function islandora_utils_drush_command() {
 }
 
 function drush_islandora_utils_ocr_consolidate() {
-  $pid = drush_get_option('pid',FALSE);
-  $pidlist =drush_get_option('pidlist',FALSE);
-
+  $pid = drush_get_option('pid', FALSE);
+  $pidlist =drush_get_option('pidlist', FALSE);
   if ($pid && $pidlist) {
     throw new Exception("'pid' and 'pidlist' are mutually exclusive options.");
   }
@@ -257,16 +256,14 @@ function drush_islandora_utils_ocr_consolidate() {
     $pidlist = trim(file_get_contents($pidlist));
     $pids = explode(',', $pidlist);
   }
+  else{
+    $pids = [$pid];
+  }
   if(isset($pids)){
     foreach($pids as $singlepid) {
       drush_print($singlepid);
       consolidate_ocr($singlepid);
     }
-  }
-  else{
-    $pid = drush_get_option('pid', FALSE);
-    drush_print($pid);
-    consolidate_ocr($pid);
   }
 }
 


### PR DESCRIPTION
Allows for consolidation of pages' ocr to be attached to parent obj (ie an issue or book)
accepts single --pid or --pidlist option, prints pid when ocr is updated.
Prints log message, and handles exceptions